### PR TITLE
新增 react-router example

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -1,0 +1,13 @@
+import React, { Component} from "react";
+
+class About extends Component{
+  render(){
+    return(
+      <div>
+        <h2>Hi there! this is About page</h2>
+      </div>
+    );
+  }
+}
+
+export default About;

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,30 @@
 import React, { Component} from "react";
 import {hot} from "react-hot-loader";
+import {BrowserRouter, Link} from "react-router-dom";
+import Router from "./Router";
 import "./App.css";
 
 class App extends Component{
   render(){
     return(
       <div className="App">
-        <h1> Hello, World! </h1>
+        <BrowserRouter>
+          <Router />
+
+          <nav>
+            <ul>
+              <li>
+                <Link to="/">Home</Link>
+              </li>
+              <li>
+                <Link to="/about/">About</Link>
+              </li>
+              <li>
+                <Link to="/users/">Users</Link>
+              </li>
+            </ul>
+          </nav>
+        </BrowserRouter>
       </div>
     );
   }

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,0 +1,13 @@
+import React, { Component} from "react";
+
+class Home extends Component{
+  render(){
+    return(
+      <div>
+        <h2>Hi there! this is Home page</h2>
+      </div>
+    );
+  }
+}
+
+export default Home;

--- a/src/NotFound.js
+++ b/src/NotFound.js
@@ -1,0 +1,11 @@
+import React, { Component} from "react";
+
+class NotFound extends Component{
+  render(){
+    return(
+      <h2>404! this page is NotFound</h2>
+    );
+  }
+}
+
+export default NotFound;

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,0 +1,22 @@
+import React, {Component} from "react";
+import {Route, Switch} from "react-router-dom";
+
+import Home from "./Home";
+import About from "./About";
+import Users from "./Users";
+import NotFound from "./NotFound";
+
+class Router extends Component{
+    render(){
+        return(
+            <Switch>
+                <Route path="/" exact component={Home} />
+                <Route path="/about/" component={About} />
+                <Route path="/users/" component={Users} />
+                <Route path="*" component={NotFound} />
+            </Switch>
+        );
+    }
+}
+
+export default Router;

--- a/src/Users.js
+++ b/src/Users.js
@@ -1,0 +1,11 @@
+import React, { Component} from "react";
+
+class Users extends Component{
+  render(){
+    return(
+      <h2>Hi there! this is Users page</h2>
+    );
+  }
+}
+
+export default Users;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,8 @@ module.exports = {
     contentBase: path.join(__dirname, "public/"),
     port: 3000,
     publicPath: "http://localhost:3000/dist/",
-    hotOnly: true
+    hotOnly: true,
+    historyApiFallback: true
   },
   plugins: [new webpack.HotModuleReplacementPlugin()]
 };


### PR DESCRIPTION
新增 react-router的基本範例

並在 webpack.config.js 裡加上
devServer: {
historyApiFallback: true
}
如果沒有這段，在非home頁重整會跳Cannot Get的問題，無法顯示頁面